### PR TITLE
fix Remove(name As String)

### DIFF
--- a/JSONItem_MTC.xojo_xml_code
+++ b/JSONItem_MTC.xojo_xml_code
@@ -1344,7 +1344,7 @@
    <SourceLine>return</SourceLine>
    <SourceLine>end if</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>ObjectValues.Remove( name )</SourceLine>
+   <SourceLine>ObjectValues.Remove( NameToKey( name ) )</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
   </ItemSource>


### PR DESCRIPTION
JSONItem_MTC class attempted to remove the name given in ObjectValues without converting it to a key.
